### PR TITLE
Update homepage to note non-public nature of google.cc.w, etc.

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,13 +27,23 @@ li {
 </head>
 <body>
   <h1>Code City</h1>
-  <p>Welcome to Code City.  Here are a list of running instances:</p>
+  <p>Welcome to Code City, a collabortive coding platform for
+  education.
+
+  <p>Here are a list of running instances:</p>
   <ul>
-    <li><a href="https://google.codecity.world/">Google Code City</a></li>
+    <li><a href="https://google.codecity.world/">Google Code
+	City</a> (prototype instance limited to Google users only)</li>
   </ul>
 
-  <p>Source repository may be found at <a href="https://github.com/google/CodeCity">https://github.com/google/CodeCity</a></p>
-
+  <p>Code City is an open source
+    project <a href="https://github.com/google/CodeCity">hosted on
+      GitHub</a>.  You can
+    <a href="https://github.com/google/CodeCity/blob/master/docs/setup.md">run
+      your own instance</a>.  To have your instance included in the
+    list above, please
+    <a href="https://github.com/NeilFraser/CodeCityHomepage/pulls">file
+      a pull request</a>.</p>
   <img id="footer" src="static/skyline.svg">
 </body>
 </html>


### PR DESCRIPTION
Noting that we've had a [couple of bugs filed against CodeCity](https://github.com/google/CodeCity/issues?q=is%3Aissue+google.codecity.world++instance) for non-accessibility of `google.codecity.world`, I thought it would be a good idea to add a note about this and also mention the fact that there are now setup instructions.